### PR TITLE
Fix parameter hints issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,22 +42,22 @@
       {
         "command": "implicit-indent.cursorUp",
         "key": "up",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible"
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !parameterHintsVisible"
       },
       {
         "command": "implicit-indent.cursorDown",
         "key": "down",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible"
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !parameterHintsVisible"
       },
       {
         "command": "implicit-indent.cursorLeft",
         "key": "left",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible"
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !parameterHintsVisible"
       },
       {
         "command": "implicit-indent.cursorRight",
         "key": "right",
-        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible"
+        "when": "editorTextFocus && !editorReadonly && !suggestWidgetVisible && !parameterHintsVisible"
       }
     ]
   },


### PR DESCRIPTION
If a parameter hint is visible then up/down commands break vscode hint logic (up/down should change the hint, but change the caret position)